### PR TITLE
Update mod-audio-to-cv.ttl

### DIFF
--- a/plugin-data/mod-cv-plugins/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl
+++ b/plugin-data/mod-cv-plugins/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl
@@ -15,7 +15,7 @@
 a lv2:Plugin, mod:ControlVoltagePlugin;
 
 doap:name "Audio to CV";
-
+doap:license "GPL v2+";
 doap:developer [
     foaf:name "Jarno Verheesen";
     foaf:homepage <>;

--- a/plugin-data/mod-cv-plugins/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl
+++ b/plugin-data/mod-cv-plugins/mod-audio-to-cv.lv2/mod-audio-to-cv.ttl
@@ -15,7 +15,7 @@
 a lv2:Plugin, mod:ControlVoltagePlugin;
 
 doap:name "Audio to CV";
-doap:license "GPL v2+";
+doap:license "https://spdx.org/licenses/GPL-2.0-or-later.html";
 doap:developer [
     foaf:name "Jarno Verheesen";
     foaf:homepage <>;


### PR DESCRIPTION
Add doap:license.  Compiling plugin for MOD on the Raspberry Pi and missing license during build.